### PR TITLE
feat: parse `expire_at` date for link

### DIFF
--- a/src/routes/Linx.svelte
+++ b/src/routes/Linx.svelte
@@ -57,7 +57,7 @@
       <dt class="block underline">Original URL</dt>
       <dd>{link.original_url}</dd>
       <dt class="block underline">Expires</dt>
-      <dd>{link.expires_at}</dd>
+      <dd>{new Date(link.expires_at).toLocaleDateString()}</dd>
     </dl>
     <div class="flex flex-col">
       <a


### PR DESCRIPTION
In this pull request, I'm parsing `expiration_date` for a more friendly date.